### PR TITLE
Added 'Storage Class' option

### DIFF
--- a/s3_multipart_uploader.py
+++ b/s3_multipart_uploader.py
@@ -194,7 +194,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--storage-class',
         default='STANDARD',
-        help='s3 storage class for the file. Possible values - STANDARD|REDUCED_REDUNDANCY|STANDARD_IA|ONEZONE_IA|INTELLIGENT_TIERING|GLACIER|DEEP_ARCHIVE',
+        help='s3 storage class for the file. Possible values - STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER | DEEP_ARCHIVE',
     )
     args = parser.parse_args()
     upload_file(

--- a/tests/test_s3_multipart_uploader.py
+++ b/tests/test_s3_multipart_uploader.py
@@ -20,13 +20,13 @@ class TestS3MultipartUploader(unittest.TestCase):
 
     # 50 bytes
     SMALL_TESTFILE_CONTENT = "+ELokXtvOjByfb92hqVRE74SOaA0B2AS3iwtPkjv74HTY76sqt"
-    SMALL_TESTFILE_PATH = os.path.join(os.curdir, 'tests', 'small_testfile')
+    SMALL_TESTFILE_PATH = os.path.join(os.curdir, 'small_testfile')
 
     BIG_TESTFILE_SIZE = 6*1024*1024
-    BIG_TESTFILE_PATH = os.path.join(os.curdir, 'tests', 'big_testfile')
+    BIG_TESTFILE_PATH = os.path.join(os.curdir, 'big_testfile')
 
     def setUp(self):
-        testfile = open(self.SMALL_TESTFILE_PATH, 'wb')
+        testfile = open(self.SMALL_TESTFILE_PATH, 'w')
         testfile.write(self.SMALL_TESTFILE_CONTENT)
 
     def tearDown(self):
@@ -91,6 +91,7 @@ class TestS3MultipartUploader(unittest.TestCase):
                 original_filename=self.BIG_TESTFILE_PATH,
                 file_piece_size=5*1024*1024 + 100,
                 keep_file_pieces=False,
+                storage_class='STANDARD'
             )
 
             key = os.path.basename(self.BIG_TESTFILE_PATH)


### PR DESCRIPTION
- AWS S3 provides different storage class options (ex. STANDARD, GLACIER, DEEP_ARCHIVE etc.)
- As part of this pull request, I added the optional parameter --storage-class so that user can choose between the options rather than using just the STANDARD (default)
- One more change is - the 'partial' reading of file did not work, so you see a change there; if that is big of a concern, then will post the details
- In the unit test, I removed 'test' directory in path.join; because my test was already running inside 'test' directory; and I think, this change will make it generic (because anyways the file is going to be deleted after execution)